### PR TITLE
Fix BIMI SVG base profile

### DIFF
--- a/bimi/kelh-bimi.svg
+++ b/bimi/kelh-bimi.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny-ps" width="256" height="256" viewBox="0 0 256 256">
   <title>kelh.net BIMI mark</title>
   <rect width="256" height="256" rx="40" fill="#0f4c81"/>
   <path fill="#ffffff" d="M86 56h28v68l68-68h26l-71 70 74 74h-26l-71-68v68H86z"/>


### PR DESCRIPTION
## Summary
- update BIMI logo SVG to use baseProfile="tiny-ps" (version 1.2) to satisfy BIMI validation

## Testing
- not run (static asset change)
