### PR TITLE
Simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,10 @@
 # kelh.net
 
-Static site for the kelh.net domain owned by @atiradonet. This repository hosts the public landing page served via GitHub Pages.
+The home for kelh.net, a simple public landing page maintained by @atiradonet.
 
-## About
+## What’s here
 
-- Purpose: provide a concise, standards-compliant HTML home page for kelh.net.
-- Tech: plain HTML and CSS; no build step.
-- Hosting: GitHub Pages (from the default branch).
-
-## BIMI
-
-- BIMI logo is served at `https://kelh.net/bimi/kelh-bimi.svg` (SVG Tiny, square).
-- DNS TXT record without a VMC (limited provider support):  
-  `default._bimi.kelh.net. IN TXT "v=BIMI1; l=https://kelh.net/bimi/kelh-bimi.svg;"`  
-- When you obtain a VMC, update the record to include it:  
-  `default._bimi.kelh.net. IN TXT "v=BIMI1; l=https://kelh.net/bimi/kelh-bimi.svg; a=<VMC_URL>"`  
-  Many providers (e.g., Gmail, Yahoo) require a VMC to display the mark.
-- Prereqs: DMARC at enforcement (`p=quarantine` or `p=reject`) with aligned SPF/DKIM for mail you send as kelh.net.
-- If you move the logo, update `l=` in DNS and keep the file public over HTTPS.
+The site keeps a concise introduction to kelh.net and a short note on clarity. It also includes a security page with disclosure guidance for researchers.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- reduce README to a brief description of the kelh.net site and its security page
- remove technical/implementation details

## Testing
- not run (docs only)
