### PR TITLE
Add security/github links and clarify timelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,12 @@
       color: var(--muted);
       font-size: 1rem;
     }
+    nav {
+      margin-top: 12px;
+      display: flex;
+      gap: 14px;
+      font-size: 0.98rem;
+    }
     section {
       margin-top: 24px;
       line-height: 1.6;
@@ -81,6 +87,10 @@
     <header>
       <h1>kelh.net</h1>
       <p>A clear, simple home on the web.</p>
+      <nav aria-label="Site links">
+        <a href="/security">Security</a>
+        <a href="https://github.com/atiradonet/kelh.net">GitHub repo</a>
+      </nav>
     </header>
 
     <section aria-labelledby="quote">

--- a/security/index.html
+++ b/security/index.html
@@ -107,8 +107,8 @@
     <section aria-labelledby="commitment">
       <h2 id="commitment">Our commitment</h2>
       <ul>
-        <li>Acknowledge reports within 30 days.</li>
-        <li>Provide status updates at least every 30 days until resolution.</li>
+        <li>Acknowledge reports within 30 business days.</li>
+        <li>Provide status updates at least every 30 business days until resolution.</li>
         <li>Coordinate disclosure timelines with you.</li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- add homepage links to the security page and GitHub repo
- clarify security response/update commitments to at least 30 business days

## Testing
- not run (static content)
