### PR TITLE
Refactor nav and styling with shared components

### DIFF
--- a/assets/nav.js
+++ b/assets/nav.js
@@ -1,0 +1,12 @@
+class SiteNav extends HTMLElement {
+  async connectedCallback() {
+    try {
+      const resp = await fetch('/partials/nav.html', { cache: 'force-cache' });
+      this.innerHTML = resp.ok ? await resp.text() : '';
+    } catch (err) {
+      this.innerHTML = '';
+    }
+  }
+}
+
+customElements.define('site-nav', SiteNav);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,109 @@
+:root {
+  color-scheme: light;
+  --bg: #f8f9fa;
+  --panel: #ffffff;
+  --text: #0f172a;
+  --accent: #0f4c81;
+  --muted: #475569;
+  --border: #e2e8f0;
+  --shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  --radius: 16px;
+  --space: 16px;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 20% 20%, #e6eef6, #f8f9fa 35%), var(--bg);
+  color: var(--text);
+}
+
+main {
+  width: min(760px, 94vw);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: calc(var(--space) * 2);
+  box-shadow: var(--shadow);
+}
+
+header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2rem);
+  letter-spacing: 0.02em;
+}
+
+header p {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+nav[aria-label="Site links"] {
+  display: flex;
+  gap: 14px;
+  font-size: 0.98rem;
+  margin-bottom: calc(var(--space) * 1.25);
+}
+
+section {
+  margin-top: calc(var(--space) * 1.5);
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+section h2 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+blockquote {
+  margin: 16px 0;
+  padding: 16px 20px;
+  border-left: 4px solid var(--accent);
+  background: #f1f5f9;
+  color: var(--text);
+  font-style: italic;
+}
+
+cite {
+  display: block;
+  margin-top: 8px;
+  color: var(--muted);
+  font-style: normal;
+  font-size: 0.95rem;
+}
+
+footer {
+  margin-top: 28px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { scroll-behavior: auto; }
+  main { box-shadow: none; }
+}

--- a/index.html
+++ b/index.html
@@ -5,96 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="kelh.net — a concise home on the web.">
   <title>kelh.net</title>
-  <style>
-    :root {
-      color-scheme: light;
-      --bg: #f8f9fa;
-      --text: #0f172a;
-      --accent: #0f4c81;
-      --muted: #475569;
-      font-family: "Helvetica Neue", Arial, sans-serif;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: radial-gradient(circle at 20% 20%, #e6eef6, #f8f9fa 35%), var(--bg);
-      color: var(--text);
-    }
-    main {
-      width: min(640px, 92vw);
-      background: #ffffff;
-      border: 1px solid #e2e8f0;
-      border-radius: 16px;
-      padding: 32px;
-      box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
-    }
-    header h1 {
-      margin: 0 0 8px;
-      font-size: 1.9rem;
-      letter-spacing: 0.02em;
-    }
-    header p {
-      margin: 0;
-      color: var(--muted);
-      font-size: 1rem;
-    }
-    nav {
-      margin-top: 12px;
-      display: flex;
-      gap: 14px;
-      font-size: 0.98rem;
-    }
-    section {
-      margin-top: 24px;
-      line-height: 1.6;
-      font-size: 1.05rem;
-    }
-    blockquote {
-      margin: 16px 0;
-      padding: 16px 20px;
-      border-left: 4px solid var(--accent);
-      background: #f1f5f9;
-      color: var(--text);
-      font-style: italic;
-    }
-    cite {
-      display: block;
-      margin-top: 8px;
-      color: var(--muted);
-      font-style: normal;
-      font-size: 0.95rem;
-    }
-    footer {
-      margin-top: 28px;
-      color: var(--muted);
-      font-size: 0.95rem;
-    }
-    a {
-      color: var(--accent);
-      text-decoration: none;
-    }
-    a:hover, a:focus-visible {
-      text-decoration: underline;
-    }
-  </style>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <script type="module" src="/assets/nav.js"></script>
 </head>
 <body>
   <main>
     <header>
       <h1>kelh.net</h1>
       <p>A clear, simple home on the web.</p>
-      <nav aria-label="Site links">
-        <a href="/security">Security</a>
-        <a href="https://github.com/atiradonet/kelh.net">GitHub repo</a>
-      </nav>
+      <site-nav></site-nav>
     </header>
 
     <section aria-labelledby="quote">
-      <h2 id="quote" style="margin:0 0 8px; font-size:1.1rem; color: var(--muted); letter-spacing:0.01em;">On speaking clearly</h2>
+      <h2 id="quote">On speaking clearly</h2>
       <blockquote>
         “Everything that can be said can be said clearly; and whereof one cannot speak, thereof one must be silent.”
         <cite>— Ludwig Wittgenstein, Tractatus Logico-Philosophicus</cite>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,0 +1,5 @@
+<nav aria-label="Site links">
+  <a href="/">Home</a>
+  <a href="/security">Security</a>
+  <a href="https://github.com/atiradonet/kelh.net">GitHub repo</a>
+</nav>

--- a/security/index.html
+++ b/security/index.html
@@ -5,87 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="kelh.net vulnerability disclosure and security policy.">
   <title>kelh.net Security</title>
-  <style>
-    :root {
-      color-scheme: light;
-      --bg: #f8f9fa;
-      --panel: #ffffff;
-      --text: #0f172a;
-      --muted: #475569;
-      --accent: #0f4c81;
-      --border: #e2e8f0;
-      font-family: "Helvetica Neue", Arial, sans-serif;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: radial-gradient(circle at 20% 20%, #e6eef6, #f8f9fa 35%), var(--bg);
-      color: var(--text);
-    }
-    main {
-      width: min(760px, 94vw);
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 32px;
-      box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
-      line-height: 1.6;
-    }
-    header h1 {
-      margin: 0 0 8px;
-      font-size: 1.9rem;
-      letter-spacing: 0.02em;
-    }
-    header p {
-      margin: 0 0 16px;
-      color: var(--muted);
-      font-size: 1rem;
-    }
-    nav {
-      margin-bottom: 20px;
-    }
-    nav a {
-      color: var(--accent);
-      text-decoration: none;
-      font-size: 0.95rem;
-    }
-    nav a:hover, nav a:focus-visible { text-decoration: underline; }
-    section { margin-top: 20px; }
-    h2 {
-      margin: 0 0 8px;
-      font-size: 1.15rem;
-      letter-spacing: 0.01em;
-    }
-    ul {
-      padding-left: 18px;
-      margin: 8px 0 0;
-    }
-    li { margin-bottom: 6px; }
-    code {
-      background: #f1f5f9;
-      padding: 2px 6px;
-      border-radius: 6px;
-      font-size: 0.95rem;
-    }
-    .meta {
-      margin-top: 24px;
-      color: var(--muted);
-      font-size: 0.95rem;
-    }
-    a { color: var(--accent); text-decoration: none; }
-    a:hover, a:focus-visible { text-decoration: underline; }
-  </style>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <script type="module" src="/assets/nav.js"></script>
 </head>
 <body>
   <main>
-    <nav><a href="/">← Back to kelh.net</a></nav>
     <header>
       <h1>Security</h1>
       <p>We welcome vulnerability reports and will work with you in good faith to resolve issues.</p>
+      <site-nav></site-nav>
     </header>
 
     <section aria-labelledby="scope">


### PR DESCRIPTION
## Summary
- add shared nav partial and Web Component to render Home/Security/GitHub links
- move styling to external CSS with modern variables, clamp(), focus states, and reduced-motion handling
- refactor index and security pages to use semantic structure with the shared nav

## Testing
- not run (static content)
