### PR TITLE
Route security reports to GitHub

### DIFF
--- a/security/index.html
+++ b/security/index.html
@@ -27,7 +27,7 @@
     <section aria-labelledby="reporting">
       <h2 id="reporting">How to report</h2>
       <ul>
-        <li>Email: <a href="mailto:rpt@kelh.net">rpt@kelh.net</a></li>
+        <li>File an issue: <a href="https://github.com/atiradonet/kelh.net/issues">github.com/atiradonet/kelh.net/issues</a></li>
         <li>Include: affected host/path, clear steps to reproduce, expected vs. actual behavior, impact, and any proof-of-concept. Screenshots or short logs are helpful.</li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- remove email contact from security page
- point reporters to GitHub issues at github.com/atiradonet/kelh.net/issues

## Testing
- not run (static content)
