### PR TITLE
Align footer and clarify security validity

### DIFF
--- a/security/index.html
+++ b/security/index.html
@@ -65,9 +65,13 @@
       <p>PGP/other encrypted channels are not yet available. If needed later, we’ll publish the key and note it in <code>/.well-known/security.txt</code>.</p>
     </section>
 
-    <div class="meta">
-      Last updated: 2025-12-09. Canonical policy: <a href="https://kelh.net/security">https://kelh.net/security</a>
-    </div>
+    <p class="meta">
+      Last updated: 2025-12-09. Canonical policy: <a href="https://kelh.net/security">https://kelh.net/security</a>. Validity tracked via <code>/.well-known/security.txt</code> Expires.
+    </p>
+
+    <footer>
+      Content © 2024 atiradonet. For permissions or inquiries, please reach out via GitHub.
+    </footer>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the same footer as the homepage to the security page for consistency
- keep policy metadata as a meta note and mention validity is tracked via /.well-known/security.txt Expires

## Testing
- not run (static content)
