### PR TITLE
Tighten homepage copy and link footers

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,10 @@
         “Everything that can be said can be said clearly; and whereof one cannot speak, thereof one must be silent.”
         <cite>— Ludwig Wittgenstein, Tractatus Logico-Philosophicus</cite>
       </blockquote>
-      <p>This site aims to keep things concise and intelligible—nothing more than needed, nothing less.</p>
     </section>
 
     <footer>
-      Content © 2024 atiradonet. For permissions or inquiries, please reach out via GitHub.
+      Content © 2024 <a href="https://github.com/atiradonet">atiradonet</a>. For permissions or inquiries, please reach out via GitHub.
     </footer>
   </main>
 </body>

--- a/security/index.html
+++ b/security/index.html
@@ -70,7 +70,7 @@
     </p>
 
     <footer>
-      Content © 2024 atiradonet. For permissions or inquiries, please reach out via GitHub.
+      Content © 2024 <a href="https://github.com/atiradonet">atiradonet</a>. For permissions or inquiries, please reach out via GitHub.
     </footer>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- remove redundant explanatory sentence under the quote on the homepage
- turn footer author text into a link to https://github.com/atiradonet on both pages

## Testing
- not run (static content)
