### PR TITLE
Add shared footer component

### DIFF
--- a/assets/nav.js
+++ b/assets/nav.js
@@ -10,3 +10,16 @@ class SiteNav extends HTMLElement {
 }
 
 customElements.define('site-nav', SiteNav);
+
+class SiteFooter extends HTMLElement {
+  async connectedCallback() {
+    try {
+      const resp = await fetch('/partials/footer.html', { cache: 'force-cache' });
+      this.innerHTML = resp.ok ? await resp.text() : '';
+    } catch (err) {
+      this.innerHTML = '';
+    }
+  }
+}
+
+customElements.define('site-footer', SiteFooter);

--- a/index.html
+++ b/index.html
@@ -24,9 +24,7 @@
       </blockquote>
     </section>
 
-    <footer>
-      Content © 2024 <a href="https://github.com/atiradonet">atiradonet</a>. For permissions or inquiries, please reach out via GitHub.
-    </footer>
+    <site-footer></site-footer>
   </main>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  Content © 2024 <a href="https://github.com/atiradonet">atiradonet</a>. For permissions or inquiries, please reach out via GitHub.
+</footer>

--- a/security/index.html
+++ b/security/index.html
@@ -69,9 +69,7 @@
       Last updated: 2025-12-09. Canonical policy: <a href="https://kelh.net/security">https://kelh.net/security</a>. Validity tracked via <code>/.well-known/security.txt</code> Expires.
     </p>
 
-    <footer>
-      Content © 2024 <a href="https://github.com/atiradonet">atiradonet</a>. For permissions or inquiries, please reach out via GitHub.
-    </footer>
+    <site-footer></site-footer>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared footer partial and load it via the existing Web Component pattern
- replace inline footers on index and security pages with <site-footer>
- keep footer content identical across pages (GitHub-linked attribution)

## Testing
- not run (static content)
