### PR TITLE
Fix issue #16: remove stray Expires

### DIFF
--- a/security/index.html
+++ b/security/index.html
@@ -66,7 +66,7 @@
     </section>
 
     <p class="meta">
-      Last updated: 2025-12-09. Canonical policy: <a href="https://kelh.net/security">https://kelh.net/security</a>. Validity tracked via <code>/.well-known/security.txt</code> Expires.
+      Last updated: 2025-12-09. Canonical policy: <a href="https://kelh.net/security">https://kelh.net/security</a>. Validity tracked via <code>/.well-known/security.txt</code>.
     </p>
 
     <site-footer></site-footer>


### PR DESCRIPTION
## Summary
- remove the extra word "Expires" from the security policy meta note
- validity now reads: "Validity tracked via /.well-known/security.txt."

## Testing
- not run (static content)

Resolves: #16
