### PR TITLE
Add site URL to README and link license in nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kelh.net
 
-The home for kelh.net, a simple public landing page maintained by @atiradonet.
+The home for kelh.net, a simple public landing page maintained by @atiradonet. Visit https://kelh.net.
 
 ## What’s here
 

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -2,4 +2,5 @@
   <a href="/">Home</a>
   <a href="/security">Security</a>
   <a href="https://github.com/atiradonet/kelh.net">GitHub repo</a>
+  <a href="/LICENSE">License</a>
 </nav>


### PR DESCRIPTION
## Summary
- add the live site URL (https://kelh.net) to the README
- include a License link in the shared navigation to point to /LICENSE

## Testing
- not run (static content)
