### PR TITLE
Fix license fetch to comply with CSP

### DIFF
--- a/assets/license.js
+++ b/assets/license.js
@@ -1,4 +1,4 @@
-const LICENSE_URL = 'https://raw.githubusercontent.com/atiradonet/kelh.net/refs/heads/main/LICENSE';
+const LICENSE_URL = '/LICENSE';
 
 const target = document.getElementById('license-content');
 


### PR DESCRIPTION
## Summary
- load license text from same-origin /LICENSE instead of raw.githubusercontent.com to satisfy current CSP (script-src/connect-src 'self')
- keeps the license page in sync without CSP violations

## Testing
- not run (static content)
