### PR TITLE
Tighten CSP by removing unsafe-inline

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="kelh.net — a concise home on the web.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
   <meta name="robots" content="noindex, nofollow, noai, noimageai">
   <meta name="googlebot" content="noindex, nofollow, noai, noimageai">
   <title>kelh.net</title>

--- a/license.html
+++ b/license.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="License for kelh.net content.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
   <meta name="robots" content="noindex, nofollow, noai, noimageai">
   <meta name="googlebot" content="noindex, nofollow, noai, noimageai">
   <title>kelh.net License</title>

--- a/security/index.html
+++ b/security/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="kelh.net vulnerability disclosure and security policy.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
   <meta name="robots" content="noindex, nofollow, noai, noimageai">
   <meta name="googlebot" content="noindex, nofollow, noai, noimageai">
   <title>kelh.net Security</title>


### PR DESCRIPTION
## Summary
- keep all scripts external and remove 'unsafe-inline' from script-src on all pages
- retain connect-src 'self' for license fetch and Trusted Types directives

## Testing
- not run (CSP-only change)
