### PR TITLE
Harden Pages delivery, automate security.txt renewal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# SHA-pinned actions are immutable, which is the point — but it also means they
+# never pick up upstream security fixes on their own. Dependabot closes that gap:
+# it understands hash-pinned actions and rewrites both the SHA and the trailing
+# version comment, so pinning costs nothing in maintenance.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One PR for the Pages toolchain rather than four; these actions are
+      # released together and are only meaningful as a set.
+      github-pages:
+        patterns:
+          - "actions/checkout"
+          - "actions/configure-pages"
+          - "actions/upload-pages-artifact"
+          - "actions/deploy-pages"
+    commit-message:
+      prefix: "chore(actions)"

--- a/.github/workflows/security-txt-renew.yml
+++ b/.github/workflows/security-txt-renew.yml
@@ -1,0 +1,127 @@
+# Keep .well-known/security.txt from lapsing.
+#
+# RFC 9116 makes `Expires` mandatory and conforming tooling treats a lapsed file
+# as invalid rather than merely stale — so an expired security.txt advertises the
+# disclosure channel as unmonitored. This rolls the field forward automatically.
+#
+# Why this workflow deploys the site itself rather than letting static.yml do it:
+# a push made with GITHUB_TOKEN deliberately does NOT trigger further workflow
+# runs, so committing here would update the repository but never republish the
+# page. The deploy job below closes that gap.
+name: Renew security.txt
+
+on:
+  schedule:
+    # 04:17 UTC on the 1st of each month. Off-the-hour to avoid the scheduler's
+    # peak, when GitHub delays or drops cron runs.
+    - cron: "17 4 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "security-txt-renew"
+  cancel-in-progress: false
+
+jobs:
+  renew:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      changed: ${{ steps.roll.outputs.changed }}
+      new: ${{ steps.roll.outputs.new }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Roll Expires forward when it nears lapsing
+        id: roll
+        run: |
+          set -euo pipefail
+          FILE=.well-known/security.txt
+          test -f "$FILE" || { echo "::error::$FILE is missing"; exit 1; }
+
+          current=$(grep -iE '^Expires:' "$FILE" | head -1 | cut -d: -f2- | tr -d ' \r')
+          if [ -z "$current" ]; then
+            echo "::error::no Expires field found; RFC 9116 requires one"
+            exit 1
+          fi
+          current_s=$(date -u -d "$current" +%s)
+          now_s=$(date -u +%s)
+          remaining=$(( (current_s - now_s) / 86400 ))
+          echo "Expires: $current  ($remaining days remaining)"
+
+          # Renew once inside 90 days. Checking monthly with an 11-month horizon
+          # means the file is rewritten roughly once a year, not every run.
+          if [ "$remaining" -gt 90 ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Outside the renewal window; nothing to do."
+            exit 0
+          fi
+
+          # 11 months, not 12: RFC 9116 says the value should be LESS THAN a year
+          # out, and exactly one year sits on the boundary.
+          new=$(date -u -d "+11 months" +%Y-%m-%dT23:59:00Z)
+          sed -i -E "s|^Expires:.*|Expires: $new|I" "$FILE"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          echo "Rolled Expires forward to $new"
+
+      - name: Commit
+        if: steps.roll.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .well-known/security.txt
+          git commit -m "chore(security.txt): roll Expires to ${{ steps.roll.outputs.new }}"
+          git push
+
+      - name: Summary
+        run: |
+          {
+            if [ "${{ steps.roll.outputs.changed }}" = "true" ]; then
+              echo "### security.txt renewed"
+              echo ""
+              echo "New \`Expires\`: \`${{ steps.roll.outputs.new }}\`"
+            else
+              echo "### security.txt still current"
+              echo ""
+              echo "More than 90 days remain; no change made."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Republish, because the commit above cannot trigger static.yml on its own.
+  deploy:
+    needs: renew
+    if: needs.renew.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: '.'
+          # Without this the whole point of the workflow is lost: .well-known/
+          # would be excluded from the artifact.
+          include-hidden-files: true
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,4 +1,8 @@
-# Simple workflow for deploying static content to GitHub Pages
+# Deploy static content to GitHub Pages.
+#
+# Actions are pinned to commit SHAs rather than tags: a tag is mutable and can be
+# repointed at new code, so a SHA is the only reference that cannot change under
+# us. The trailing comment records the version each SHA corresponds to.
 name: Deploy static content to Pages
 
 on:
@@ -30,14 +34,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # Upload entire repository
           path: '.'
+          # REQUIRED from v4 onward. This action now defaults to excluding
+          # dot-prefixed paths (--exclude=.[^/]*), which would silently drop
+          # .well-known/ and take security.txt off the site. v3 had no such
+          # exclusion, so omitting this while upgrading is a silent breakage.
+          include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -3,4 +3,4 @@ Contact: mailto:rpt@kelh.net
 Policy: https://kelh.net/security
 Preferred-Languages: en
 Canonical: https://kelh.net/.well-known/security.txt
-Expires: 2026-06-30T23:59:00Z
+Expires: 2027-07-13T23:59:00Z

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+kelh.net

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="kelh.net — a concise home on the web.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; base-uri 'self'; object-src 'none'; form-action 'none'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="robots" content="noindex, nofollow, noai, noimageai">
   <meta name="googlebot" content="noindex, nofollow, noai, noimageai">
   <title>kelh.net</title>

--- a/license.html
+++ b/license.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="License for kelh.net content.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; base-uri 'self'; object-src 'none'; form-action 'none'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="robots" content="noindex, nofollow, noai, noimageai">
   <meta name="googlebot" content="noindex, nofollow, noai, noimageai">
   <title>kelh.net License</title>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,12 @@
+# kelh.net is deliberately not indexed. Every page also carries
+# <meta name="robots" content="noindex, nofollow, noai, noimageai">, and this
+# file is the coarse counterpart to that. No sitemap is published — advertising
+# URLs for indexing would contradict the policy below.
+#
+# The named groups are not redundant with the wildcard: a crawler obeys only the
+# most specific group matching its token, so a bot with its own section never
+# reads the "*" rules. Each one has to be listed to be covered.
+
 User-agent: *
 Disallow: /
 
@@ -18,5 +27,3 @@ Disallow: /
 
 User-agent: Amazonbot
 Disallow: /
-
-Sitemap: https://kelh.net/sitemap.xml

--- a/security/index.html
+++ b/security/index.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="kelh.net vulnerability disclosure and security policy.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self'; base-uri 'self'; object-src 'none'; form-action 'none'; require-trusted-types-for 'script'; trusted-types kelh-nav kelh-footer;">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="robots" content="noindex, nofollow, noai, noimageai">
   <meta name="googlebot" content="noindex, nofollow, noai, noimageai">
   <title>kelh.net Security</title>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://kelh.net/</loc></url>
-  <url><loc>https://kelh.net/security</loc></url>
-  <url><loc>https://kelh.net/license.html</loc></url>
-</urlset>


### PR DESCRIPTION
Remediation from the external security assessment. No high-severity exposure was found; these are maintenance-drift fixes.

## Changes

- **`security.txt`** — `Expires` rolled to 2027-07-13 (it had lapsed 43 days ago), plus a monthly workflow that renews it inside 90 days of expiry. The renewal workflow performs the Pages deploy itself: a `GITHUB_TOKEN` push cannot trigger another workflow, so relying on `static.yml` would commit the renewed file but never republish it.
- **Actions SHA-pinned** and moved to current majors (checkout v4→v7.0.1, configure-pages v5→v6, upload-pages-artifact v3→v5, deploy-pages v4→v5). Tags are mutable; SHAs are not.
- **`include-hidden-files: true`** — `upload-pages-artifact` v4+ runs `--exclude=.[^/]*` by default, which drops `.well-known/` and would silently take `security.txt` off the site. Do not remove this.
- **Dependabot** — weekly `github-actions` updates, so the SHA pins still receive upstream fixes.
- **CSP** — adds `base-uri 'self'`, `object-src 'none'`, `form-action 'none'`. `default-src` does not cover `base-uri`, so a `<base>` injection was unblocked. Also adds `<meta name="referrer">`. `frame-ancestors` is deliberately omitted: meta-delivered CSP ignores it per spec, and Pages cannot send headers.
- **`CNAME`** — records the custom domain in-repo rather than only in repo settings.
- **`robots.txt` / `sitemap.xml`** — sitemap dropped. Every page is `noindex, nofollow, noai, noimageai`, so advertising URLs for indexing contradicted the rest of the site.

## Verify after deploy

```
curl -sS https://kelh.net/.well-known/security.txt
```

Must return content. An empty response or 404 means the hidden-files exclusion bit — roll back.